### PR TITLE
The semicolon token should not be respected.

### DIFF
--- a/one_declaration.json
+++ b/one_declaration.json
@@ -12,9 +12,9 @@
 "foo:", ["declaration", "foo", [], false],
 "foo :", ["declaration", "foo", [], false],
 "\n/**/ foo: ", ["declaration", "foo", [" "], false],
-"foo:;", ["declaration", "foo", [], false],
+"foo:;", ["declaration", "foo", [";"], false],
 " /**/ foo /**/ :", ["declaration", "foo", [], false],
-"foo:;bar:;", ["error", "extra-input"],
+"foo:;bar:;", ["declaration", "foo", [";", ["ident", "bar"], ":", ";"], false],
 
 "foo: 9000  !Important", ["declaration", "foo", [
     " ", ["number", "9000", 9000, "integer"], " "


### PR DESCRIPTION
See: http://dev.w3.org/csswg/css-syntax/#consume-a-declaration0
After consuming the colon token, it states the declaration's value is the consumption of every subsequent component value, until we reach an EOF token.

@SimonSapin
