### PR TITLE
Support CSS Nesting Module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,12 @@ associated with the expected result.
     The Unicode input is represented by a JSON string,
     the output as an array of declarations_ and at-rules_.
 
+``blocks_contents.json``
+    Tests `Parse a block’s contents
+    <http://dev.w3.org/csswg/css-syntax-3/#parse-block-contents>`_.
+    The Unicode input is represented by a JSON string,
+    the output as an array of declarations_, at-rules_ and `qualified rules`_.
+
 ``one_declaration.json``
     Tests `Parse a declaration
     <http://dev.w3.org/csswg/css-syntax-3/#parse-a-declaration>`_.

--- a/blocks_contents.json
+++ b/blocks_contents.json
@@ -1,0 +1,63 @@
+[
+
+";; /**/ ; ;", [],
+"a:b; c:d 42!important;\n", [
+    ["declaration", "a", [["ident", "b"]], false],
+    ["declaration", "c", [["ident", "d"], " ", ["number", "42", 42, "integer"]], true]
+],
+
+"z;a:b", [
+    ["error", "invalid"],
+    ["declaration", "a", [["ident", "b"]], false]
+],
+
+"z:x!;a:b", [
+    ["declaration", "z", [["ident", "x"], "!"], false],
+    ["declaration", "a", [["ident", "b"]], false]
+],
+
+"a:b; c+:d", [
+    ["declaration", "a", [["ident", "b"]], false],
+    ["error", "invalid"]
+],
+
+"@import 'foo.css'; a:b; @import 'bar.css'", [
+    ["at-rule", "import", [" ", ["string", "foo.css"]], null],
+    ["declaration", "a", [["ident", "b"]], false],
+    ["at-rule", "import", [" ", ["string", "bar.css"]], null]
+],
+
+"@media screen { div{;}} a:b;; @media print{div{", [
+    ["at-rule", "media", [" ", ["ident", "screen"], " "], [" ", ["ident", "div"], ["{}", ";"]]],
+    ["declaration", "a", [["ident", "b"]], false],
+    ["at-rule", "media", [" ", ["ident", "print"]], [["ident", "div"], ["{}"]]]
+],
+
+"@ media screen { div{;}} a:b;; @media print{div{", [
+    ["qualified rule",   ["@", " ", ["ident", "media"], " ", ["ident", "screen"], " "],   [" ", ["ident", "div"], ["{}", ";"]]],
+    ["declaration", "a", [["ident", "b"]], false],
+    ["at-rule", "media", [" ", ["ident", "print"]], [["ident", "div"], ["{}"]]]
+],
+
+"z:x;a b{c:d;;e:f}", [
+    ["declaration", "z", [["ident", "x"]], false],
+    ["qualified rule", [["ident", "a"], " ", ["ident", "b"]], [["ident", "c"], ":", ["ident", "d"], ";", ";", ["ident", "e"], ":", ["ident", "f"]]]
+],
+
+"a {c:1}", [
+    ["qualified rule", [["ident", "a"], " "], [["ident", "c"], ":", ["number", "1", 1, "integer"]]]
+],
+
+"a:hover {c:1}", [
+    ["qualified rule", [["ident", "a"], ":", ["ident", "hover"], " "], [["ident", "c"], ":", ["number", "1", 1, "integer"]]]
+],
+
+"z:x;a b{c:d}e:f", [
+    ["declaration", "z", [["ident", "x"]], false],
+    ["qualified rule", [["ident", "a"], " ", ["ident", "b"]], [["ident", "c"], ":", ["ident", "d"]]],
+    ["declaration", "e", [["ident", "f"]], false]
+],
+
+"", []
+
+]

--- a/one_declaration.json
+++ b/one_declaration.json
@@ -35,12 +35,6 @@
 ], false],
 "foo:important", ["declaration", "foo", [
     ["ident", "important"]
-], false],
-
-"foo: 9000 @bar{ !important", ["declaration", "foo", [
-    " ", ["number", "9000", 9000, "integer"], " ", ["at-keyword", "bar"], ["{}",
-        " ", "!", ["ident", "important"]
-    ]
 ], false]
 
 ]


### PR DESCRIPTION
CSS Nesting Module introduces changes in the Syntax Module, including a new "block’s content" syntax and changes in the way declarations containing curly blocks are parsed.